### PR TITLE
Mod/commands/expand cleanup

### DIFF
--- a/src/CommandList.json
+++ b/src/CommandList.json
@@ -4,40 +4,43 @@
             "length": 2,
             "delims": [" "],
             "help": "/kill <target>",
-            "hostonly": true
+            "hostonly": true,
+            "message": "%s is killing %t"
         },
         "/whisper": {
             "length": 3,
             "delims": [" ", "'"],
             "help": "/whisper <target> '<message>'",
-            "hostonly": false
+            "hostonly": false,
+            "message": "%s is whispering to %t"
         },
         "/setname": {
             "length": 2,
             "delims": [" "],
             "help": "/setname <name>",
-            "hostonly": false
+            "hostonly": false,
+            "message": "%s is setting name to %t"
         },
         "/save": {
             "length": 2,
             "delims": [" "],
             "help": "/save <filename>",
-            "hostonly": true
+            "hostonly": true,
+            "message": "%s is saving the game settings to %t"
         },
         "/load": {
             "length": 2,
             "delims": [" "],
             "help": "/load <filename>",
-            "hostonly": true
+            "hostonly": true,
+            "message": "%s is loading the game settings from %t"
         }
     },
-    "Enabled": [
-        "/kill",
-        "/whisper",
-        "/setname",
-        "/save",
-        "/load"
-    ],
-    "Disabled": [
-    ]
+    "Enabled": {
+        "/kill": true,
+        "/whisper": true,
+        "/setname": true,
+        "/save": true,
+        "/load": true
+    }
 }

--- a/src/CommandList.json
+++ b/src/CommandList.json
@@ -23,21 +23,21 @@
             "delims": [" "],
             "help": "/save <filename>",
             "hostonly": true
-        }
+        },
         "/load": {
             "length": 2,
             "delims": [" "],
             "help": "/load <filename>",
             "hostonly": true
         }
-    }
+    },
     "Enabled": [
         "/kill",
         "/whisper",
         "/setname",
         "/save",
         "/load"
-    ]
+    ],
     "Disabled": [
     ]
 }

--- a/src/CommandList.json
+++ b/src/CommandList.json
@@ -1,39 +1,39 @@
 {
     "Commands": {
         "/kill": {
-            "length": 2,
-            "delims": [" "],
-            "help": "/kill <target>",
-            "hostonly": true,
-            "message": "%s is killing %t"
+            "Length": 2,
+            "Delims": [" "],
+            "Help": "/kill <target>",
+            "Hostonly": true,
+            "Message": "%s is killing %t"
         },
         "/whisper": {
-            "length": 3,
-            "delims": [" ", "'"],
-            "help": "/whisper <target> '<message>'",
-            "hostonly": false,
-            "message": "%s is whispering to %t"
+            "Length": 3,
+            "Delims": [" ", "'"],
+            "Help": "/whisper <target> '<Message>'",
+            "Hostonly": false,
+            "Message": "%s is whispering to %t"
         },
         "/setname": {
-            "length": 2,
-            "delims": [" "],
-            "help": "/setname <name>",
-            "hostonly": false,
-            "message": "%s is setting name to %t"
+            "Length": 2,
+            "Delims": [" "],
+            "Help": "/setname <name>",
+            "Hostonly": false,
+            "Message": "%s is setting name to %t"
         },
         "/save": {
-            "length": 2,
-            "delims": [" "],
-            "help": "/save <filename>",
-            "hostonly": true,
-            "message": "%s is saving the game settings to %t"
+            "Length": 2,
+            "Delims": [" "],
+            "Help": "/save <filename>",
+            "Hostonly": true,
+            "Message": "%s is saving the game settings to %t"
         },
         "/load": {
-            "length": 2,
-            "delims": [" "],
-            "help": "/load <filename>",
-            "hostonly": true,
-            "message": "%s is loading the game settings from %t"
+            "Length": 2,
+            "Delims": [" "],
+            "Help": "/load <filename>",
+            "Hostonly": true,
+            "Message": "%s is loading the game settings from %t"
         }
     },
     "Enabled": {

--- a/src/CommandsList.txt
+++ b/src/CommandsList.txt
@@ -1,0 +1,1 @@
+/kill "%s is killing %t"

--- a/src/CommandsList.txt
+++ b/src/CommandsList.txt
@@ -1,5 +1,5 @@
-/kill "%s is killing %t"
-/whisper "%s is whispering to %t"
-/setname "%s is setting name to %t"
-/save "%s is saving the game settings to %t"
-/load "%s is loading the game settings from %t"
+/kill:    %s is killing %t
+/whisper: %s is whispering to %t
+/setname: %s is setting name to %t
+/save:    %s is saving the game settings to %t
+/load:    %s is loading the game settings from %t

--- a/src/CommandsList.txt
+++ b/src/CommandsList.txt
@@ -1,1 +1,5 @@
 /kill "%s is killing %t"
+/whisper "%s is whispering to %t"
+/setname "%s is setting name to %t"
+/save "%s is saving the game settings to %t"
+/load "%s is loading the game settings from %t"

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -338,7 +338,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (chat.StartsWith("/"))
                     {
-                        String[] commandPieces = chat.Split(" ", StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
+                        String[] commandPieces = chat.Split(" ", 2, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
 
                         var origin = sender.Character.PlayerInfo.PlayerName;
                         var dest = "";

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -347,6 +347,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         String senderCommand = chat.Split(" ", StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries)[0];
 
                         String[] commandPieces = chat.Split(commandList.Commands[senderCommand].Delims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
+
+                        Console.WriteLine("Sender command: " + senderCommand);
+                        Console.WriteLine("Command pieces length: " + commandPieces.Length);
+                        Console.WriteLine("Enabled: " + commandList.Enabled[senderCommand]);
+
                         if (commandPieces.Length == commandList.Commands[senderCommand].Length && commandList.Enabled[senderCommand])
                         {
                             var origin = sender.Character.PlayerInfo.PlayerName;

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -326,25 +326,25 @@ namespace Impostor.Server.Net.Inner.Objects
 
                         var commandsFile = "CommandList.json";
                         using FileStream openStream = File.OpenRead(commandsFile);
-                        dynamic commandList = await JsonSerializer.DeserializeAsync<dynamic>(openStream);
-                        if (commandList.Commands != JsonTokenType.Null)
+                        dynamic commandList = await JsonSerializer.DeserializeAsync<Object>(openStream);
+                        //if (commandList["Commands"] != JsonTokenType.Null)
+                        //{
+                        foreach (var command in commandList["Commands"])
                         {
-                            foreach (var command in commandList.Commands)
+                            String[] commandPieces = chat.Split(command["delims"], StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
+                            if (commandPieces[0] == command && commandPieces.Length == command["length"] && commandList["Enabled"][command])
                             {
-                                String[] commandPieces = chat.Split(command.delims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
-                                if (commandPieces[0] == command && commandPieces.Length == command.length && commandList.Enabled.command)
+                                var origin = sender.Character.PlayerInfo.PlayerName;
+                                var dest = "";
+                                if (commandPieces.Length > 1)
                                 {
-                                    var origin = sender.Character.PlayerInfo.PlayerName;
-                                    var dest = "";
-                                    if (commandPieces.Length > 1)
-                                    {
-                                        dest = commandPieces[1];
-                                    }
-                                    chatMod = command.message.Replace("%s", origin).Replace("%t", dest);
-                                    break;
+                                    dest = commandPieces[1];
                                 }
+                                chatMod = command["message"].Replace("%s", origin).Replace("%t", dest);
+                                break;
                             }
                         }
+                        //}
 
                         byte[] payload = System.Text.Encoding.ASCII.GetBytes(chatMod);
                         byte[] payloadLen = BitConverter.GetBytes(payload.Length);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -26,7 +26,7 @@ namespace Impostor.Server.Net.Inner.Objects
     internal class Command
     {
         public int Length {get; set;}
-        public String[] Delims {get; set;}
+        public Char[] Delims {get; set;}
         public String Help {get; set;}
         public bool Hostonly {get; set;}
         public String Message {get; set;}

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -327,7 +327,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         var commandsFile = "CommandList.json";
                         using FileStream openStream = File.OpenRead(commandsFile);
                         dynamic commandList = await JsonSerializer.DeserializeAsync<Object>(openStream);
-                        if (commandList.Commands == JsonTokenType.Null)
+                        if (commandList.Commands != JsonTokenType.Null)
                         {
                             foreach (var command in commandList.Commands)
                             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -327,7 +327,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         var commandList = await JsonSerializer.DeserializeAsync<Object>(openStream);
                         Type commandListType = typeof(Object);
                         commandListType.GetProperty("Commands");
-                        Console.WriteLine(commandListType.GetProperty("Commands"));
+                        Console.WriteLine("Commands property value is: " + commandListType.GetProperty("Commands"));
 
                         var chatMod = "Invalid command or syntax";
                         String[] commandPieces = chat.Split(" ", 2);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -327,7 +327,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         var commandsFile = "CommandList.json";
                         using FileStream openStream = File.OpenRead(commandsFile);
                         dynamic commandList = await JsonSerializer.DeserializeAsync<Object>(openStream);
-                        if (commandList != null)
+                        if (commandList.has("Commands") && !commandList.isNull("Commands"))
                         {
                             foreach (var command in commandList.Commands)
                             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -327,7 +327,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         var commandsFile = "CommandList.json";
                         using FileStream openStream = File.OpenRead(commandsFile);
                         dynamic commandList = await JsonSerializer.DeserializeAsync<Object>(openStream);
-                        if (commandList.has("Commands") && !commandList.isNull("Commands"))
+                        if (commandList.Commands == JsonTokenType.Null)
                         {
                             foreach (var command in commandList.Commands)
                             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -346,9 +346,9 @@ namespace Impostor.Server.Net.Inner.Objects
                         {
                             dest = commandPieces[1];
                         }
-                        
+
                         var chatMod = origin + " entered an invalid command or syntax";
-                        var commandsFile = "CommandList.txt";
+                        var commandsFile = "CommandsList.txt";
                         
                         try
                         {
@@ -366,7 +366,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         }
                         catch
                         {
-                            chatMod = "Failed to find list of commands. Inform the room host [" + _game.Host.Character.PlayerInfo.PlayerName + "]";
+                            chatMod = "Failed to find list of commands. Inform the room host <" + _game.Host.Character.PlayerInfo.PlayerName + ">";
                         }
 
                         byte[] payload = System.Text.Encoding.ASCII.GetBytes(chatMod);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -326,7 +326,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                         var commandsFile = "CommandList.json";
                         using FileStream openStream = File.OpenRead(commandsFile);
-                        dynamic commandList = await JsonSerializer.DeserializeAsync<Object>(openStream);
+                        dynamic commandList = await JsonSerializer.DeserializeAsync<dynamic>(openStream);
                         if (commandList.Commands != JsonTokenType.Null)
                         {
                             foreach (var command in commandList.Commands)

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -348,7 +348,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                         String senderCommand = chat.Split(" ", StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries)[0];
 
-                        String[] commandPieces = chat.Split(commandList.Commands[senderCommand].Delims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
+                        String[] commandPieces = chat.Split(commandList.Commands[senderCommand].Delims, commandList.Commands[senderCommand].Length, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
 
                         Console.WriteLine("Sender command: " + senderCommand);
                         Console.WriteLine("Command pieces length: " + commandPieces.Length);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -338,7 +338,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (chat.StartsWith("/"))
                     {
-                        String commandParsePattern = @"(/\w+)\s+((?:\w+\s*)+)";
+                        String commandParsePattern = @"(/\w+)\s+((?:\w+\s*)+)('.*')*";
                         var match = Regex.Match(chat, commandParsePattern);
 
                         var origin = sender.Character.PlayerInfo.PlayerName;
@@ -347,22 +347,25 @@ namespace Impostor.Server.Net.Inner.Objects
                         var chatMod = origin + " entered an invalid command or syntax";
                         var commandsFile = "CommandsList.txt";
                         
-                        try
+                        if (!(match.Groups[1].Value == "/whisper" && !match.Groups[3].Success))
                         {
-                            foreach (var line in File.ReadLines(commandsFile))
+                            try
                             {
-                                Char[] commandDelims = {':'};
-                                var commandSyntax = line.Split(commandDelims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
-                                if (commandSyntax[0] == match.Groups[1].Value)
+                                foreach (var line in File.ReadLines(commandsFile))
                                 {
-                                    chatMod = commandSyntax[1].Replace("%s", origin).Replace("%t", dest);
-                                    break;
+                                    Char[] commandDelims = {':'};
+                                    var commandSyntax = line.Split(commandDelims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
+                                    if (commandSyntax[0] == match.Groups[1].Value)
+                                    {
+                                        chatMod = commandSyntax[1].Replace("%s", origin).Replace("%t", dest);
+                                        break;
+                                    }
                                 }
                             }
-                        }
-                        catch
-                        {
-                            chatMod = "Failed to find list of commands. Inform the room host <" + _game.Host.Character.PlayerInfo.PlayerName + ">";
+                            catch
+                            {
+                                chatMod = "Failed to find list of commands. Inform the room host <" + _game.Host.Character.PlayerInfo.PlayerName + ">";
+                            }
                         }
 
                         byte[] payload = System.Text.Encoding.ASCII.GetBytes(chatMod);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -338,7 +338,9 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (chat.StartsWith("/"))
                     {
-                        var chatMod = "Invalid command or syntax";
+                        var origin = sender.Character.PlayerInfo.PlayerName;
+
+                        var chatMod = origin + " entered an invalid command or syntax";
 
                         var commandsFile = "CommandList.json";
                         using FileStream openStream = File.OpenRead(commandsFile);
@@ -351,10 +353,13 @@ namespace Impostor.Server.Net.Inner.Objects
                         Console.WriteLine("Sender command: " + senderCommand);
                         Console.WriteLine("Command pieces length: " + commandPieces.Length);
                         Console.WriteLine("Enabled: " + commandList.Enabled[senderCommand]);
+                        foreach (var c in commandPieces)
+                        {
+                            Console.WriteLine("Command piece: " + c);
+                        }
 
                         if (commandPieces.Length == commandList.Commands[senderCommand].Length && commandList.Enabled[senderCommand])
                         {
-                            var origin = sender.Character.PlayerInfo.PlayerName;
                             var dest = "";
                             if (commandPieces.Length > 1)
                             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -355,7 +355,7 @@ namespace Impostor.Server.Net.Inner.Objects
                             var lines = File.ReadLines(commandsFile);
                             foreach (var line in lines)
                             {
-                                Char[] commandDelims = {' ', '"'};
+                                Char[] commandDelims = {':'};
                                 var commandSyntax = line.Split(commandDelims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
                                 if (commandSyntax[0] == commandPieces[0])
                                 {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -338,7 +338,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (chat.StartsWith("/"))
                     {
-                        String commandParsePattern = @"(/\w+)\s+((?:\w+\s+)+)";
+                        String commandParsePattern = @"(/\w+)\s+((?:\w+\s*)+)";
                         var match = Regex.Match(chat, commandParsePattern);
 
                         var origin = sender.Character.PlayerInfo.PlayerName;
@@ -349,8 +349,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         
                         try
                         {
-                            var lines = File.ReadLines(commandsFile);
-                            foreach (var line in lines)
+                            foreach (var line in File.ReadLines(commandsFile))
                             {
                                 Char[] commandDelims = {':'};
                                 var commandSyntax = line.Split(commandDelims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Impostor.Api;
@@ -338,14 +338,11 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (chat.StartsWith("/"))
                     {
-                        String[] commandPieces = chat.Split(" ", 2, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
+                        String commandParsePattern = @"(/\w+)\s+((?:\w+\s+)+)";
+                        var match = Regex.Match(chat, commandParsePattern);
 
                         var origin = sender.Character.PlayerInfo.PlayerName;
-                        var dest = "";
-                        if (commandPieces.Length > 1)
-                        {
-                            dest = commandPieces[1];
-                        }
+                        var dest = match.Groups[2].Value.Trim();
 
                         var chatMod = origin + " entered an invalid command or syntax";
                         var commandsFile = "CommandsList.txt";
@@ -357,7 +354,7 @@ namespace Impostor.Server.Net.Inner.Objects
                             {
                                 Char[] commandDelims = {':'};
                                 var commandSyntax = line.Split(commandDelims, StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries);
-                                if (commandSyntax[0] == commandPieces[0])
+                                if (commandSyntax[0] == match.Groups[1].Value)
                                 {
                                     chatMod = commandSyntax[1].Replace("%s", origin).Replace("%t", dest);
                                     break;


### PR DESCRIPTION
### Description

Added regex checking for commands. Regex may need to be expanded in the future. General syntax of a command is `/<command> <target>`. Only special case currently is whispering, which is `/<command> <target> '<message>'`. If more special cases arise, regex may need to be changed.

Also added very simple text file for commands. Each command has a name and a message that prints to all other players when someone calls the command. File format is `<command>: <message>`, where `<message>` contains `%s` which is replaced with the name of the sender of the command, and `%d` which is replaced with the destination of the command. 